### PR TITLE
Fix lint config and allure report path

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+import js from '@eslint/js';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import prettierPlugin from 'eslint-plugin-prettier';
+
+export default [
+  {
+    files: ['**/*.{ts,js}'],
+    ignores: ['node_modules/', 'dist/'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        ...js.environments.browser.globals,
+        ...js.environments.node.globals,
+        ...js.environments.es2021.globals,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      prettier: prettierPlugin,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...tsPlugin.configs.recommended.rules,
+      'prettier/prettier': 'error',
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coupons": "npx playwright test tests/cinesa/coupons/coupons.spec.ts",
     "ui": "npx playwright test --ui",
     "lint": "eslint . --ext .ts,.js",
-    "report": "npx allure generate allure-results -o allure-report && npx allure open allure-report/awesome",
+    "report": "npx allure generate allure-results -o allure-report && npx allure open allure-report",
     "watch-report": "npx allure watch allure-results",
     "codegen": "npx playwright codegen https://www.cinesa.es",
     "test:whoarewe": "npx playwright test tests/cinesa/whoarewe/whoarewe.spec.ts",


### PR DESCRIPTION
## Summary
- add `eslint.config.js` for ESLint 9 support
- fix the `report` script path for Allure

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862ad005b4483209783d757bd820355