### PR TITLE
Harden consent handling against OneTrust overlays

### DIFF
--- a/core/webactions/webActions.ts
+++ b/core/webactions/webActions.ts
@@ -2,6 +2,7 @@ import { expect, Page, Locator } from '@playwright/test';
 import { allure } from 'allure-playwright';
 import { CorsHandler } from './corsHandler';
 import { step, mask, truncate } from './steps';
+import { ensureConsentClosed } from '../../helpers/consent';
 
 /**
  * WebActions provides a unified, abstracted interface for all Playwright browser interactions.
@@ -113,6 +114,7 @@ export class WebActions {
 
     await step(`[NAV] Goto | URL=${urlPath} | Env=${env}`, async () => {
       await this.page.goto(url);
+      await ensureConsentClosed(this.page);
     });
   }
 

--- a/fixtures/cinesa/playwright.fixtures.ts
+++ b/fixtures/cinesa/playwright.fixtures.ts
@@ -22,6 +22,7 @@ import { Mailing } from '../../pageObjectsManagers/cinesa/mailing/mailing.page';
 import { AnalyticsPage } from '../../pageObjectsManagers/cinesa/analytics/analytics.page';
 import { MovieList } from '../../pageObjectsManagers/cinesa/movies/movies.page';
 import { MoviePage } from '../../pageObjectsManagers/cinesa/movie/movie.page';
+import { ensureConsentClosed } from '../../helpers/consent';
 
 type CustomFixtures = {
   navbar: Navbar;
@@ -280,6 +281,14 @@ export const test = base.extend<CustomFixtures>({
     const moviePage = new MoviePage(page);
     await use(moviePage);
   },
+});
+
+test.beforeEach(async ({ page }) => {
+  await ensureConsentClosed(page);
+});
+
+test.afterEach(async ({ page }) => {
+  await ensureConsentClosed(page);
 });
 
 export { expect } from '@playwright/test';

--- a/helpers/consent.ts
+++ b/helpers/consent.ts
@@ -1,0 +1,120 @@
+import { Page } from '@playwright/test';
+
+const SELECTORS = {
+  banner: '#onetrust-banner-sdk',
+  acceptButton: '#onetrust-accept-btn-handler',
+  preferenceCenter: '#onetrust-pc-sdk',
+  closeButtons: ['#close-pc-btn-handler', '.ot-close-icon', '.onetrust-close-btn-handler'],
+  overlays: [
+    '.onetrust-pc-dark-filter',
+    '.banner-actions-container',
+    '#onetrust-consent-sdk',
+  ],
+} as const;
+
+async function locatorVisible(page: Page, selector: string): Promise<boolean> {
+  try {
+    return await page.locator(selector).isVisible();
+  } catch {
+    return false;
+  }
+}
+
+async function waitForHidden(page: Page, selector: string, timeout = 5000): Promise<void> {
+  try {
+    await page.locator(selector).waitFor({ state: 'hidden', timeout });
+  } catch {
+    // Swallow timeout - we'll neutralize overlays later if needed
+  }
+}
+
+function log(message: string): void {
+  console.log(`ℹ️ [ConsentGuard] ${message}`);
+}
+
+/**
+ * Ensure OneTrust consent UI elements are fully dismissed before interacting with the page.
+ *
+ * The helper is idempotent and safe to call multiple times within the same test.
+ * It performs three steps:
+ * 1. Accept the cookie banner when present
+ * 2. Close the preference center if it is open
+ * 3. Neutralize leftover overlay layers that could intercept clicks
+ */
+export async function ensureConsentClosed(page: Page): Promise<void> {
+  if (!page) {
+    return;
+  }
+
+  const bannerVisible = await locatorVisible(page, SELECTORS.banner);
+  if (bannerVisible) {
+    log('Cookie banner detected – accepting all cookies.');
+    const acceptButton = page.locator(SELECTORS.acceptButton);
+    try {
+      await acceptButton.click({ timeout: 5000 });
+    } catch (error) {
+      log(`Accept button click failed (${String(error)}).`);
+    }
+    await waitForHidden(page, SELECTORS.banner);
+  }
+
+  const preferenceCenterVisible = await locatorVisible(page, SELECTORS.preferenceCenter);
+  if (preferenceCenterVisible) {
+    log('Preference center detected – attempting graceful close.');
+    for (const closeSelector of SELECTORS.closeButtons) {
+      if (await locatorVisible(page, closeSelector)) {
+        try {
+          await page.locator(closeSelector).click({ timeout: 3000 });
+          break;
+        } catch (error) {
+          log(`Close button ${closeSelector} click failed (${String(error)}).`);
+        }
+      }
+    }
+    await waitForHidden(page, SELECTORS.preferenceCenter, 4000);
+  }
+
+  const overlaysStillBlocking = [] as string[];
+  for (const selector of SELECTORS.overlays) {
+    if (await locatorVisible(page, selector)) {
+      overlaysStillBlocking.push(selector);
+    }
+  }
+
+  if (overlaysStillBlocking.length > 0) {
+    log(
+      `Neutralizing persistent overlays: ${overlaysStillBlocking
+        .map((selector) => selector)
+        .join(', ')}`
+    );
+    await page.evaluate((blockingSelectors) => {
+      blockingSelectors.forEach((selector) => {
+        document.querySelectorAll(selector).forEach((element) => {
+          const el = element as HTMLElement;
+          el.style.setProperty('display', 'none', 'important');
+          el.style.setProperty('visibility', 'hidden', 'important');
+          el.style.setProperty('pointer-events', 'none', 'important');
+          el.setAttribute('data-consent-guard', 'neutralized');
+        });
+      });
+    }, overlaysStillBlocking);
+
+    await page
+      .waitForFunction((blockingSelectors) => {
+        return blockingSelectors.every((selector) => {
+          const node = document.querySelector(selector) as HTMLElement | null;
+          if (!node) {
+            return true;
+          }
+          const styles = window.getComputedStyle(node);
+          const invisible =
+            styles.visibility === 'hidden' ||
+            styles.display === 'none' ||
+            styles.opacity === '0' ||
+            node.offsetParent === null;
+          return invisible;
+        });
+      }, overlaysStillBlocking, { timeout: 2000 })
+      .catch(() => {});
+  }
+}

--- a/state/consented.production.es.json
+++ b/state/consented.production.es.json
@@ -77,7 +77,7 @@
       "path": "/",
       "expires": 1794587178,
       "httpOnly": false,
-      "secure": false,
+      "secure": true,
       "sameSite": "Lax"
     },
     {
@@ -137,7 +137,7 @@
       "path": "/",
       "expires": 1794587178,
       "httpOnly": false,
-      "secure": false,
+      "secure": true,
       "sameSite": "Lax"
     },
     {

--- a/tests/cinesa/footer/components/cookiespolicy/cookiespolicy.spec.ts
+++ b/tests/cinesa/footer/components/cookiespolicy/cookiespolicy.spec.ts
@@ -3,6 +3,7 @@ import { allure } from 'allure-playwright';
 import { expectedUrl } from './cookiespolicy.data';
 import { assertCookiesPolicyNavigation } from './cookiespolicy.assertions';
 import { takeScreenshot } from '../../../../../pageObjectsManagers/cinesa/generic/generic';
+import { ensureConsentClosed } from '../../../../../helpers/consent';
 
 test.describe('Cookies Policy Tests', () => {
   test.beforeEach(async ({ footer }) => {
@@ -10,6 +11,10 @@ test.describe('Cookies Policy Tests', () => {
     await allure.feature('Footer - Site Navigation');
 
     await footer.navigateToHome();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await ensureConsentClosed(page);
   });
 
   test(

--- a/tests/cinesa/seatPicker/seatPicker.spec.ts
+++ b/tests/cinesa/seatPicker/seatPicker.spec.ts
@@ -13,6 +13,7 @@ import { ticketTypeMappings } from '../ticketPicker/ticketPicker.data';
 import { PROMO_CODE_OPTIONS } from '../../../pageObjectsManagers/cinesa/ticketPicker/ticketPicker.data';
 //import { assertNoCloudflareProtection } from '../../helpers/cloudflareDetector';
 import { getCinemasForEnvironment } from './seatPicker.data';
+import { ensureConsentClosed } from '../../../helpers/consent';
 
 // Get available cinemas for current environment
 const CINEMAS = getCinemasForEnvironment();
@@ -24,6 +25,7 @@ test.describe('Seat Picker - Seat Selection', () => {
 
     await navbar.navigateToHome();
     //await assertNoCloudflareProtection(page, 'beforeEach setup');
+    await ensureConsentClosed(page);
   });
 
   test.describe('Complete Purchase Flow', () => {


### PR DESCRIPTION
## Summary
- add an idempotent consent guard that accepts the banner, closes the preference centre and neutralises leftover OneTrust overlays
- invoke the guard from shared fixtures, core navigation helpers and the seat picker suite to avoid state leakage
- mark persisted Optanon cookies as secure and clean up the cookies policy suite after exercising the consent UI

## Testing
- not run (requires project VPN credentials and TEST_ENV secrets)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162b066d84833098dec2066563c24f)